### PR TITLE
Update the rubocop gem.

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,2 +1,3 @@
 Cerner Corporation
 Jerrod Carpenter
+Matt Henkes

--- a/Gemfile
+++ b/Gemfile
@@ -11,5 +11,5 @@ end
 # build-time dependencies
 gem 'rake', '~> 10.0'
 gem 'rspec', '~> 3.4'
-gem 'rubocop', '~> 0.47'
+gem 'rubocop', '~> 0.52'
 gem 'simplecov', '~> 0.13'

--- a/lib/icontrol_rest/client.rb
+++ b/lib/icontrol_rest/client.rb
@@ -42,7 +42,7 @@ module IcontrolRest
         end
       end
     end
-    # rubocop:enable Metrics/ParameterList
+    # rubocop:enable Metrics/ParameterLists
 
     # Public: Returns a set logger. If none exists, a NullLogger is returned for stability.
     def logger


### PR DESCRIPTION
### Summary
There is a potential security vulnerability in the currently consumed version of rubocop. This shouldn't be an issue since it's a build time dependency, but lets update anyway. 

Thanks for contributing to icontrol_rest. 

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
